### PR TITLE
Fix alert during fetching bar prices

### DIFF
--- a/src/pages/barList.jsx
+++ b/src/pages/barList.jsx
@@ -86,7 +86,6 @@ const BarList = () => {
       // Store fetched data and current city in sessionStorage
       sessionStorage.setItem("barPrices", JSON.stringify(sortedData));
       sessionStorage.setItem("cachedCity", currentCity);
-      setReportCorrectionSuccess(true);
     } catch (error) {
       setError(error.message);
     }


### PR DESCRIPTION
Stop the correction submission success alert from being displayed when bar prices were being fetched.

addresses issue #108 